### PR TITLE
Bugfix - getresponse_customs data insert with 2 store view active

### DIFF
--- a/GetResponseIntegration/Setup/InstallSchema.php
+++ b/GetResponseIntegration/Setup/InstallSchema.php
@@ -188,7 +188,7 @@ class InstallSchema implements InstallSchemaInterface
                 'id',
                 \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
                 null,
-                ['identity' => true, 'unsigned' => true, 'nullable' => false, 'primary' => true],
+                ['identity' => true, 'unsigned' => true, 'nullable' => false, 'primary' => true, 'auto_increment' => true],
                 'Id'
             )
             ->addColumn(
@@ -345,15 +345,15 @@ class InstallSchema implements InstallSchemaInterface
         $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
         $stores = $objectManager->get('Magento\Store\Model\StoreManagerInterface')->getStores();
         foreach ($stores as $store) {
-            $installer->getConnection()->insertMultiple($installer->getTable('getresponse_customs'), ['id'=>1, 'id_shop'=>$store->getId(), 'custom_field'=>'firstname', 'custom_value'=>'firstname', 'custom_name'=>'firstname', 'default'=>1, 'active_custom'=>1]);
-            $installer->getConnection()->insertMultiple($installer->getTable('getresponse_customs'), ['id'=>2, 'id_shop'=>$store->getId(), 'custom_field'=>'lastname', 'custom_value'=>'lastname', 'custom_name'=>'lastname', 'default'=>1, 'active_custom'=>1]);
-            $installer->getConnection()->insertMultiple($installer->getTable('getresponse_customs'), ['id'=>3, 'id_shop'=>$store->getId(), 'custom_field'=>'email', 'custom_value'=>'email', 'custom_name'=>'email', 'default'=>1, 'active_custom'=>1]);
-            $installer->getConnection()->insertMultiple($installer->getTable('getresponse_customs'), ['id'=>4, 'id_shop'=>$store->getId(), 'custom_field'=>'street', 'custom_value'=>'street', 'custom_name'=>'magento_street', 'default'=>0, 'active_custom'=>0]);
-            $installer->getConnection()->insertMultiple($installer->getTable('getresponse_customs'), ['id'=>5, 'id_shop'=>$store->getId(), 'custom_field'=>'postcode', 'custom_value'=>'postcode', 'custom_name'=>'magento_postcode', 'default'=>0, 'active_custom'=>0]);
-            $installer->getConnection()->insertMultiple($installer->getTable('getresponse_customs'), ['id'=>6, 'id_shop'=>$store->getId(), 'custom_field'=>'city', 'custom_value'=>'city', 'custom_name'=>'magento_city', 'default'=>0, 'active_custom'=>0]);
-            $installer->getConnection()->insertMultiple($installer->getTable('getresponse_customs'), ['id'=>7, 'id_shop'=>$store->getId(), 'custom_field'=>'telephone', 'custom_value'=>'telephone', 'custom_name'=>'magento_telephone', 'default'=>0, 'active_custom'=>0]);
-            $installer->getConnection()->insertMultiple($installer->getTable('getresponse_customs'), ['id'=>8, 'id_shop'=>$store->getId(), 'custom_field'=>'country', 'custom_value'=>'country', 'custom_name'=>'magento_country', 'default'=>0, 'active_custom'=>0]);
-            $installer->getConnection()->insertMultiple($installer->getTable('getresponse_customs'), ['id'=>9, 'id_shop'=>$store->getId(), 'custom_field'=>'birthday', 'custom_value'=>'birthday', 'custom_name'=>'magento_birthday', 'default'=>0, 'active_custom'=>0]);
+            $installer->getConnection()->insertMultiple($installer->getTable('getresponse_customs'), ['id_shop'=>$store->getId(), 'custom_field'=>'firstname', 'custom_value'=>'firstname', 'custom_name'=>'firstname', 'default'=>1, 'active_custom'=>1]);
+            $installer->getConnection()->insertMultiple($installer->getTable('getresponse_customs'), ['id_shop'=>$store->getId(), 'custom_field'=>'lastname', 'custom_value'=>'lastname', 'custom_name'=>'lastname', 'default'=>1, 'active_custom'=>1]);
+            $installer->getConnection()->insertMultiple($installer->getTable('getresponse_customs'), ['id_shop'=>$store->getId(), 'custom_field'=>'email', 'custom_value'=>'email', 'custom_name'=>'email', 'default'=>1, 'active_custom'=>1]);
+            $installer->getConnection()->insertMultiple($installer->getTable('getresponse_customs'), ['id_shop'=>$store->getId(), 'custom_field'=>'street', 'custom_value'=>'street', 'custom_name'=>'magento_street', 'default'=>0, 'active_custom'=>0]);
+            $installer->getConnection()->insertMultiple($installer->getTable('getresponse_customs'), ['id_shop'=>$store->getId(), 'custom_field'=>'postcode', 'custom_value'=>'postcode', 'custom_name'=>'magento_postcode', 'default'=>0, 'active_custom'=>0]);
+            $installer->getConnection()->insertMultiple($installer->getTable('getresponse_customs'), ['id_shop'=>$store->getId(), 'custom_field'=>'city', 'custom_value'=>'city', 'custom_name'=>'magento_city', 'default'=>0, 'active_custom'=>0]);
+            $installer->getConnection()->insertMultiple($installer->getTable('getresponse_customs'), ['id_shop'=>$store->getId(), 'custom_field'=>'telephone', 'custom_value'=>'telephone', 'custom_name'=>'magento_telephone', 'default'=>0, 'active_custom'=>0]);
+            $installer->getConnection()->insertMultiple($installer->getTable('getresponse_customs'), ['id_shop'=>$store->getId(), 'custom_field'=>'country', 'custom_value'=>'country', 'custom_name'=>'magento_country', 'default'=>0, 'active_custom'=>0]);
+            $installer->getConnection()->insertMultiple($installer->getTable('getresponse_customs'), ['id_shop'=>$store->getId(), 'custom_field'=>'birthday', 'custom_value'=>'birthday', 'custom_name'=>'magento_birthday', 'default'=>0, 'active_custom'=>0]);
         }
 
         $installer->endSetup();


### PR DESCRIPTION
If you have 2 store_view configurated the loop that insert the data inside the getresponse_customs table will be called twice.

This is the error on php bin/magento setup:upgrade

[Zend_Db_Statement_Exception]                                                                                                                                                                                           
SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '1' for key 'PRIMARY', query was: INSERT INTO `getresponse_customs` (`id`, `id_shop`, `custom_field`, `custom_value`, `custom_name`, `default`,   
`active_custom`) VALUES (?, ?, ?, ?, ?, ?, ?)                                                                                                                                                                           
                                                                                                                                                                                                                          
[PDOException]                                                         
SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '1' for key 'PRIMARY'

I've setted for the id field the auto_increment  flag (to auto generate the id) and I've removed the id in the data for each entry.